### PR TITLE
Release 1.1.0

### DIFF
--- a/bot/api/__init__.py
+++ b/bot/api/__init__.py
@@ -18,7 +18,7 @@ class API(ABC):
 
     @property
     def headers(self) -> dict[str, Any]:
-        return {'Referer': 'https://www.platform.com/'}
+        return {}
 
     @property
     @abstractmethod

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.5
+python-3.9


### PR DESCRIPTION
Hotfix for Heroku python version: bump to 3.9

Remove default headers value from API class (so if in child class this property is not overrided, it will not affect the request)