### PR TITLE
Fix Likee 204 No-Content response

### DIFF
--- a/bot/data/__init__.py
+++ b/bot/data/__init__.py
@@ -1,0 +1,1 @@
+from .video import VideoData

--- a/bot/data/video.py
+++ b/bot/data/video.py
@@ -1,0 +1,8 @@
+from attr import attrs, attrib
+from typing import Optional
+
+
+@attrs(slots=True, auto_attribs=True, order=False, eq=False)
+class VideoData:
+    url: Optional[str] = attrib(default=None)
+    content: Optional[bytes] = attrib(default=None)

--- a/bot/handlers/messages.py
+++ b/bot/handlers/messages.py
@@ -16,12 +16,16 @@ platforms = [tiktok, likee]
 async def get_message(message: Message):
     for api in platforms:
         for video in await api.handle_message(message):
-            if video:
+            if video.content:
                 await bot.send_video(
-                    message.chat.id, video, reply_to_message_id=message.message_id
+                    message.chat.id, video.content, reply_to_message_id=message.message_id
+                )
+            elif video.url:
+                await bot.send_message(
+                    message.chat.id, video.url, reply_to_message_id=message.message_id
                 )
             else:
-                sentry_sdk.capture_exception(HandleException(str(message)))
+                sentry_sdk.capture_exception(HandleException(message.text))
                 await bot.send_message(
                     message.chat.id, DOWNLOAD_ERROR, reply_to_message_id=message.message_id
                 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+attr~=0.3.1
 httpx~=0.16.1
 beautifulsoup4~=4.9.3
 aiogram~=2.11.2


### PR DESCRIPTION
Likee was detecting Heroku environment (probably by IP or something) and returning 204 No-Content response for direct video link
Though it was acting normally for full page request.
So to prevent this, I added a check if there was a Content, if not - bot will send a direct link itself.
In this case, video will be downloaded by telegram correctly